### PR TITLE
Grip Mechanic improvements

### DIFF
--- a/Assets/Prefabs/Players NEW.prefab
+++ b/Assets/Prefabs/Players NEW.prefab
@@ -244,11 +244,18 @@ MonoBehaviour:
   m_isJumping: 0
   m_isFalling: 0
   m_isSwinging: 0
-  m_isGripping: 0
+  m_isGrabbing: 0
+  m_canGrab: 0
+  m_canMove: 0
+  m_grabRadius: 1.2
+  m_grabbableLayer:
+    serializedVersion: 2
+    m_Bits: 2048
   m_otherPlayer: {fileID: 0}
   m_bond: {fileID: 0}
   m_xInput: 0
   m_yInput: 0
+  m_viewGrabCircle: 0
 --- !u!1 &8050295438740226934
 GameObject:
   m_ObjectHideFlags: 0
@@ -474,11 +481,18 @@ MonoBehaviour:
   m_isJumping: 0
   m_isFalling: 0
   m_isSwinging: 0
-  m_isGripping: 0
+  m_isGrabbing: 0
+  m_canGrab: 0
+  m_canMove: 0
+  m_grabRadius: 1.2
+  m_grabbableLayer:
+    serializedVersion: 2
+    m_Bits: 2048
   m_otherPlayer: {fileID: 0}
   m_bond: {fileID: 0}
   m_xInput: 0
   m_yInput: 0
+  m_viewGrabCircle: 0
 --- !u!232 &8665894722799807364
 DistanceJoint2D:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Players/Character.cs
+++ b/Assets/Scripts/Players/Character.cs
@@ -84,6 +84,10 @@ public class Character : MonoBehaviour
     [SerializeField]
     private float m_grabRadius = 1.5f;
 
+    // Layer Mask   
+    [SerializeField]
+    private LayerMask m_grabbableLayer = 11;
+
     // OBJECT REFERENCES
     [Header("Object References")]
     // Other player
@@ -200,6 +204,7 @@ public class Character : MonoBehaviour
         }
     }
 
+
     /*
      * UPDATE METHOD
      * 
@@ -211,6 +216,18 @@ public class Character : MonoBehaviour
      */
     void Update()
     {
+        // Check if player is within the grabable layer
+        if (Physics2D.OverlapCircle(GetPlayerPosition(), m_grabRadius, m_grabbableLayer))
+        {
+            // Set can grab boolean to true
+            m_canGrab = true;
+        }
+        else
+        {
+            // Set can grab boolean to false
+            m_canGrab = false;
+        }
+
         // DEBUG - View grab circle code
         {
             // DEBUG - Check if the view grab circle is enabled
@@ -228,8 +245,6 @@ public class Character : MonoBehaviour
             // Update the grab circle
             UpdateGrabCircle();
         }
-
-
 
         // Determine half the height of the sprite
         float halfHeight = transform.GetComponent<SpriteRenderer>().bounds.extents.y;
@@ -613,11 +628,11 @@ public class Character : MonoBehaviour
     public void Grab()
     {
         // Check if the player can grab
-        // if (m_canGrab)
-        //{
+        if (m_canGrab)
+        {
             // Set is grabbing to true
             m_isGrabbing = true;
-        //}
+        }
     }
 
     /*

--- a/Assets/Wwise/Editor/ProjectData/AkWwiseProjectData.asset
+++ b/Assets/Wwise/Editor/ProjectData/AkWwiseProjectData.asset
@@ -41,7 +41,7 @@ MonoBehaviour:
     ParentPath: Master-Mixer Hierarchy\Andy's_Master-Mixer_Hierarchy\Andy's_Work_Unit
     guid: a6fc5fe531789d4f9941e4385aa4879c
     GuidInternal: 
-    m_lastTime: -8585741250483749223
+    m_lastTime: -8585738768191219680
     List:
     - name: Master
       guid: 9e2090c0c626aa4898effbd28e8ebae5
@@ -167,7 +167,7 @@ MonoBehaviour:
     ParentPath: SoundBanks\Default Work Unit
     guid: 57531442cb4f8a479ae9131731cae77e
     GuidInternal: 
-    m_lastTime: -8585741250483235179
+    m_lastTime: -8585738768190740603
     List:
     - name: General_SoundBank
       guid: ed1fbc9cffffc845b0ec06456e9ddc0c
@@ -284,7 +284,7 @@ MonoBehaviour:
     ParentPath: Events\James'_Event_Folder\James'_Work_Unit
     guid: 8a432c8051c8e94fa7b3f9a79a43cb88
     GuidInternal: 
-    m_lastTime: -8585741250489194084
+    m_lastTime: -8585738768196490028
     List:
     - name: Environment
       guid: 21dce2aed516bb449e5e924774476129
@@ -606,7 +606,7 @@ MonoBehaviour:
     ParentPath: Game Parameters\Andy's_Game_Parameters\Andy's_Work_Unit
     guid: 14872f9a9730574ab09ac575da2abb29
     GuidInternal: 
-    m_lastTime: -8585741250489184095
+    m_lastTime: -8585738768196480089
     List:
     - name: Master_Volume
       guid: 9ad7e400b89d6d41b0e05196a66b4b7a


### PR DESCRIPTION
Improvements made to the grip mechanic.

Players can only grab when they are within a radius of the environment layer. Current radius set to 1.2f, may require tweaking in the future.